### PR TITLE
Compile fix for AArch64

### DIFF
--- a/NormalizModule.cpp
+++ b/NormalizModule.cpp
@@ -60,7 +60,7 @@ static string cone_name_str_long( cone_name_long );
 
 // Check GCC
 #if __GNUC__
-#if __x86_64__ || __ppc64__
+#if __x86_64__ || __ppc64__ || __aarch64__
 #define ENVIRONMENT64
 #else
 #define ENVIRONMENT32


### PR DESCRIPTION
This adds AArch64 to the check for defining ENVIRONMENT64, which allows the code to build on this architecture.